### PR TITLE
DOS-392 Fix for Alert rules files are not being removed by the playbook

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,2 @@
-sergio.charpinel@ebury.com
+# Default code owners
+* @Ebury/DOS @Ebury/PC

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -12,15 +12,15 @@
   notify:
     - reload prometheus
 
-- name: copy custom alerting rule files
-  copy:
-    src: "{{ item }}"
+- name: Synchronize custom alerting rule files
+  synchronize:
+    src: "{{ item | dirname }}/"
     dest: "{{ prometheus_config_dir }}/rules/"
-    owner: root
-    group: prometheus
-    mode: 0640
-    validate: "{{ _prometheus_binary_install_dir }}/promtool check rules %s"
-  with_fileglob: "{{ prometheus_alert_rules_files }}"
+    delete: true
+    perms: false
+    group: false
+    owner: false
+  loop: "{{ prometheus_alert_rules_files }}"
   notify:
     - reload prometheus
 

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -135,3 +135,13 @@
   when:
     - ansible_version.full is version('2.4', '>=')
     - ansible_selinux.status == "enabled"
+
+- name: Install rsync
+  apt:
+    update_cache: true
+    pkg:
+      - rsync
+  register: _download_packages
+  until: _download_packages is succeeded
+  retries: 5
+  delay: 2


### PR DESCRIPTION
I've changed the `copy` method with a `synchronize` method. Tested locally in development environment and worked well.

I'm also updating CODEOWNERS of this new repo.