### PR TITLE
DOS-392 Fix synlink copies in the synchronize module

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -20,6 +20,7 @@
     perms: false
     group: false
     owner: false
+    copy_links: true
   loop: "{{ prometheus_alert_rules_files }}"
   register: _prometheus_sync_rules
   notify:


### PR DESCRIPTION
There is a symlink (`business_hours.rule` file) that was not being copied since the default option is to copy the symlink instead of the linked file. 

Hope that's the last fix since now I've tested in development server and the reload is working nicely :face_with_head_bandage: 