### PR TITLE
DOS-440 Discover subdirectories in rules folder

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -86,6 +86,8 @@ prometheus_config_file: 'prometheus.yml.j2'
 prometheus_alert_rules_files:
   - prometheus/rules/*.rules
 
+prometheus_alert_rules_files_subdirs: []
+
 prometheus_static_targets_files:
   - prometheus/targets/*.yml
   - prometheus/targets/*.json

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -36,6 +36,18 @@
     mode: 0770
   when: _prometheus_sync_rules is changed
 
+- name: Find all custom alerting rule files subdirectories
+  find:
+    paths: "{{ prometheus_config_dir }}/rules"
+    recurse: no
+    file_type: directory
+  register: _prometheus_local_alert_rules_files_subdirs
+
+- name: Build a list of all the custom alerting rule files directories.
+  set_fact:
+    prometheus_alert_rules_files_subdirs: "{{ prometheus_alert_rules_files_subdirs }} + [ '{{ prometheus_config_dir }}/rules/{{ item.path | basename }}/*.rules' ]"
+  with_items: "{{ _prometheus_local_alert_rules_files_subdirs.files }}"
+
 - name: configure prometheus
   template:
     src: "{{ prometheus_config_file }}"

--- a/templates/prometheus.yml.j2
+++ b/templates/prometheus.yml.j2
@@ -19,6 +19,9 @@ remote_read:
 
 rule_files:
   - {{ prometheus_config_dir }}/rules/*.rules
+  {% if prometheus_alert_rules_files_subdirs != [] %}
+  {{ prometheus_alert_rules_files_subdirs | to_nice_yaml(indent=2,sort_keys=False) | indent(2,False) }}
+  {% endif %}
 
 {% if prometheus_alertmanager_config | length > 0 %}
 alerting:


### PR DESCRIPTION
Prometheus [does not support glob in rule paths, only in filenames](https://github.com/prometheus/prometheus/issues/2487). Since we want to split rules into different folders for applying CODEOWNERS, we could have two approachs:
1. Add a new line under `rule_files:` config element for each subfolder (this PR)
2. Move all of the rules files to the root `rules` folder. 

I preferred the first option to avoid problems when we have files with the same name but under different paths. Also it will be better organized in the Prometheus UI.

We could be manually adding it to the `prometheus_alert_rules_files` Ansible var but it is error prone. 

So this PR is automating this step, discovering all of the subfolders and adding them to the config file.

Tested running locally the playbook against DXP and DEVEL envs.